### PR TITLE
Fixing a README typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Description
 This cookbook utilizes the minitest-chef-handler project to facilitate cookbook testing.
 
 minitest-chef-handler project: https://github.com/calavera/minitest-chef-handler  
-stable minitest-handler cookbook: http://community.opscode.com/cookbook/minitest-handler  
+stable minitest-handler cookbook: http://community.opscode.com/cookbooks/minitest-handler  
 minitest-handler cookbook development: https://github.com/btm/minitest-handler-cookbook  
 
 Attributes


### PR DESCRIPTION
Bryan,

there's a typo in the README for the URL to the cookbook site.  This pull request adds in the missing "s"

Cheers!
Nathen
