### PR TITLE
Add recursive create for minitest test directory

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -15,6 +15,7 @@ directory "minitest test location" do
   path node[:minitest][:path]
   owner "root"
   group "root"
+  recursive true
 end
 
 ruby_block "delete tests from old cookbooks" do


### PR DESCRIPTION
Adding recursive directory creation to prevent failure if /var/chef directory doesn't exist yet.  I hit this failure on a fresh box:

```
[Wed, 25 Apr 2012 20:00:40 +0200] ERROR: Running exception handlers
[Wed, 25 Apr 2012 20:00:40 +0200] FATAL: Saving node information to /srv/chef/file_store/failed-run-data.json
[Wed, 25 Apr 2012 20:00:40 +0200] ERROR: Exception handlers complete
[Wed, 25 Apr 2012 20:00:40 +0200] FATAL: Stacktrace dumped to /srv/chef/file_store/chef-stacktrace.out
[Wed, 25 Apr 2012 20:00:40 +0200] FATAL: Errno::ENOENT: directory[minitest test location] (minitest-handler::default line 14) had an error: No such file or directory - /var/chef/minitest
```
