### PR TITLE
Ensure minitest gem is used

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,1 +1,2 @@
 default[:minitest][:path] = "/var/chef/minitest"
+default[:minitest][:gem_version] = "3.0.1"

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -1,5 +1,6 @@
 # Hack to install Gem immediately pre Chef 0.10.10 (CHEF-2879)
 gem_package "minitest" do
+  version node[:minitest][:gem_version]
   action :nothing
 end.run_action(:install)
 
@@ -8,6 +9,8 @@ gem_package "minitest-chef-handler" do
 end.run_action(:install)
 
 Gem.clear_paths
+# Ensure minitest gem is utilized
+gem "minitest"
 require "minitest-chef-handler"
 
 # Directory to store cookbook tests


### PR DESCRIPTION
I added `minitest-handler-cookbook` to the run list of a node with Ruby `1.9.2-p290` and received the following error:

```
[Mon, 28 May 2012 14:52:51 +0000] INFO: *** Chef 0.10.10 ***
[Mon, 28 May 2012 14:52:52 +0000] INFO: Setting the run_list to ["recipe[minitest-handler]", "recipe[wharton-networks]", "recipe[sshd]", "recipe[apt]", "recipe[apt::cacher-ng]", "recipe[ntp]", "recipe[sudo]", "recipe[wharton-users]"] from JSON
[Mon, 28 May 2012 14:52:52 +0000] INFO: Run List is [recipe[minitest-handler], recipe[wharton-networks], recipe[sshd], recipe[apt], recipe[apt::cacher-ng], recipe[ntp], recipe[sudo], recipe[wharton-users]]
[Mon, 28 May 2012 14:52:52 +0000] INFO: Run List expands to [minitest-handler, wharton-networks, sshd, apt, apt::cacher-ng, ntp, sudo, wharton-users]
[Mon, 28 May 2012 14:52:52 +0000] INFO: Starting Chef Run for vagrant.vm
[Mon, 28 May 2012 14:52:52 +0000] INFO: Running start handlers
[Mon, 28 May 2012 14:52:52 +0000] INFO: Start handlers complete.
[Mon, 28 May 2012 14:52:52 +0000] INFO: Processing gem_package[minitest] action install (minitest-handler::default line 2)
[Mon, 28 May 2012 14:52:52 +0000] INFO: Processing gem_package[minitest-chef-handler] action install (minitest-handler::default line 6)
[Mon, 28 May 2012 14:53:08 +0000] INFO: gem_package[minitest-chef-handler] installed version 0.5.0
[Mon, 28 May 2012 14:53:08 +0000] ERROR: Running exception handlers
[Mon, 28 May 2012 14:53:08 +0000] ERROR: Exception handlers complete
[Mon, 28 May 2012 14:53:08 +0000] FATAL: Stacktrace dumped to /tmp/vagrant-chef-1/chef-stacktrace.out
[Mon, 28 May 2012 14:53:08 +0000] FATAL: NoMethodError: undefined method `register_spec_type' for MiniTest::Spec:Class
```

After ensuring that the minitest gem gets used instead of Ruby's built-in minitest, the Chef run completes successfully.
