### PR TITLE
Fix to TypeError when chef-client runs as a daemon

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -72,6 +72,6 @@ handler = MiniTest::Chef::Handler.new({
   :verbose => true})
 
 Chef::Log.info("Enabling minitest-chef-handler as a report handler")
-Chef::Config.send("report_handlers").delete_if {|v| v.class.to_s.include? MiniTest::Chef::Handler}
+Chef::Config.send("report_handlers").delete_if {|v| v.class.to_s.include? MiniTest::Chef::Handler.to_s}
 Chef::Config.send("report_handlers") << handler
 


### PR DESCRIPTION
When chef-client runs as a daemon, minitest-handler-cookbook fails with "TypeError: can't convert Class into String". It does not fail when run from a terminal. This change simply directly retrieves the class name.
