### PR TITLE
Add Minitest Handler options as attributes

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,5 +1,6 @@
 default['minitest']['gem_version'] = "3.0.1"
 default['minitest']['tests'] = "**/*_test.rb"
+default['minitest']['verbose'] = true
 
 case node['os']
 when "windows"

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -67,9 +67,15 @@ recipes.each do |recipe|
   end
 end
 
-handler = MiniTest::Chef::Handler.new({
+options = {
   :path    => "#{node['minitest']['path']}/#{node['minitest']['tests']}",
-  :verbose => true})
+  :verbose => node['minitest']['verbose']}
+# The following options can be omited
+options[:filter]     = node['minitest']['filter'] if node['minitest'].include? 'filter'
+options[:seed]       = node['minitest']['seed'] if node['minitest'].include? 'seed'
+options[:ci_reports] = node['minitest']['ci_reports'] if node['minitest'].include? 'ci_reports'
+
+handler = MiniTest::Chef::Handler.new(options)
 
 Chef::Log.info("Enabling minitest-chef-handler as a report handler")
 Chef::Config.send("report_handlers").delete_if {|v| v.class.to_s.include? MiniTest::Chef::Handler.to_s}


### PR DESCRIPTION
Right now the MiniTest Handler's option `verbose` is harcoded in the recipe and the only option that can be configured is the `path`.

I found particulary annoying the option `verbose` so I created an attribute to be able of change it. But also I've added the possibility to pass the rest of the options as attributes in your recipe, role or wherever.

As the other options have default values or they are not always used, I just add the posibility to pass them, but I didn't add an attribute. Mostly to avoid overwrite the default values from the minitest itself.

I hope you like the feature and I'll be happy to make any changes you ask me.
Cheers
