### PR TITLE
Add explicit cookbook name to metadata.rb

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -1,3 +1,4 @@
+name             "minitest-handler"
 maintainer       "Bryan Berry"
 maintainer_email "bryan.berry@gmail.com"
 license          "Apache 2.0"


### PR DESCRIPTION
Better than relying on cookbook directory and plays better with Berkshelf.

I have signed my contributors agreement :smile: 
