### PR TITLE
Include test files of recipes that is in the hash of node.run_state[:seen_recipes]

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,6 +4,6 @@ maintainer_email "bryan.berry@gmail.com"
 license          "Apache 2.0"
 description      "Installs and configures minitest-chef-handler"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "0.1.3"
+version          "0.1.4"
 
 depends "chef_handler"

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -12,7 +12,13 @@ Gem.clear_paths
 # Ensure minitest gem is utilized
 require "minitest-chef-handler"
 
-recipes = node['recipes']
+if Chef::VERSION < 11.0
+  seen_recipes = node.run_state[:seen_recipes]
+  recipes = seen_recipes.keys.each { |i| i }
+else
+  recipes = node["run_list"]
+end
+
 if recipes.empty? and Chef::Config[:solo]
   #If you have roles listed in your run list they are NOT expanded
   recipes = node.run_list.map {|item| item.name if item.type == :recipe }


### PR DESCRIPTION
**This will require the "minitest-handler::recipe" to be executed as the last item in the run-list.**

This is done with the intention to allow users to run tests-files that correspond to recipes that are included in the chef-run via the method, include_recipe.
