### PR TITLE
check both old_path and new_path when attempting to download tests from chef server

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -90,7 +90,7 @@ ruby_block "load tests" do
         [old_path, new_path].each do |test_path|
           begin
             # This will raise at compile-time if we can't find the directory
-            ckbk.preferred_manifest_records_for_directory(node, 'files', old_path)
+            ckbk.preferred_manifest_records_for_directory(node, 'files', test_path)
 
             # copy the test files
             ckbk_d = Chef::Resource::RemoteDirectory.new("tests-support-#{cookbook_name}-#{recipe_name}", run_context)


### PR DESCRIPTION
This should address the problem in #43 where it would not check for the new_path ('test') directory when trying to download tests with chef-client.
