### PR TITLE
Add optional drive prefix to support windows

### DIFF
--- a/libraries/test_loader.rb
+++ b/libraries/test_loader.rb
@@ -222,7 +222,7 @@ module MinitestHandler
         # when the cookbook_file resource goes to place the file
         relative_file_name = cb_file.dup
         Array(Chef::Config[:cookbook_path]).each do |cb_path|
-          dir_prefix = ::File.join(cb_path, cookbook_name, 'files', 'default', '/')
+          dir_prefix = Regexp.new '[A-Za-z]?:?' + ::File.join(cb_path, cookbook_name, 'files', 'default', '/')
           relative_file_name.gsub!(dir_prefix, '')
         end
         relative_file_names << relative_file_name


### PR DESCRIPTION
Add drive prefix to regex to fix root issue (described in https://github.com/btm/minitest-handler-cookbook/issues/60) on windows where it was unable to find tests as the convert-full-file-path-to-relatative-path functionality was failing.

Wasn't sure of how to write a test for this (and relatively new to ruby).
