### PR TITLE
Added functionality to lock in gem ci_reporter

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,9 @@ If you have any helper libraries, they should match `files/default/test/*helper*
 * `node[:minitest][:chef_handler_gem_version]` - The version of the [minitest-chef-handler](http://rubygems.org/gems/minitest-chef-handler)
   gem to install and use. 
   * Default: 1.0.1
+* `node[:minitest][:ci_reporter_gem_version]` - The version of the [ci_reporter](http://rubygems.org/gems/ci_reporter)
+  gem to install and use.
+  * Default: 1.9.2
 * `node[:minitest][:path]` - Location to store and find test files. 
   * Default: `/var/chef/minitest`
 * `node[:minitest][:recipes]` - The names of all recipes included during the 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -4,6 +4,9 @@ default[:minitest][:gem_version] = '3.0.1'
 # The version of the minitest-chef-handler gem to install
 default[:minitest][:chef_handler_gem_version] = '1.0.2'
 
+# The version of the ci_reporter gem to install
+default[:minitest][:ci_reporter_gem_version] = '1.9.2'
+
 default[:minitest][:tests] = '**/*_test.rb'
 default[:minitest][:recipes] = []
 default[:minitest][:verbose] = true

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -1,5 +1,10 @@
 ::Chef::Resource::RubyBlock.send(:include, MinitestHandler::CookbookHelper)
 
+chef_gem 'ci_reporter' do
+  version node[:minitest][:ci_reporter_gem_version]
+  action :nothing
+end.run_action(:install)
+
 # Hack to install Gem immediately pre Chef 0.10.10 (CHEF-2879)
 chef_gem 'minitest' do
   version node[:minitest][:gem_version]


### PR DESCRIPTION
The gem ci_reporter released a new version which is not backwards
compatible with the current minitest-chef-handler gem. The gem that 
was release on Jul 24 is version 2.0.0.

This change will lock in the version of the gem ci_reporter to '1.9.2'
