### PR TITLE
Feature/minitest chef handler source

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ If you have any helper libraries, they should match `files/default/test/*helper*
 * `node[:minitest][:chef_handler_gem_version]` - The version of the [minitest-chef-handler](http://rubygems.org/gems/minitest-chef-handler)
   gem to install and use.
   * Default: 1.0.3
+* `node[:minitest][:chef_handler_gem_source]` - Alternate remote source for the minitest-chef-handler gem if not using RubyGems.org.(Ex http://mysource.com/gems')
+  * Default: RubyGems.org
 * `node[:minitest][:ci_reporter_gem_version]` - The version of the [ci_reporter](http://rubygems.org/gems/ci_reporter)
   gem to install and use.
   * Default: 1.9.2

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -2,7 +2,9 @@
 default[:minitest][:gem_version] = '3.0.1'
 
 # The version of the minitest-chef-handler gem to install
-default[:minitest][:chef_handler_gem_version] = '1.0.3'
+default[:minitest][:chef_handler_gem_version] = '1.0.4'
+default[:minitest][:chef_handler_gem_source] = \
+  'http://artrepo.daptiv.com:8081/artifactory/rubygems-local/gems'
 
 # The version of the ci_reporter gem to install
 default[:minitest][:ci_reporter_gem_version] = '1.9.3'

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -3,8 +3,7 @@ default[:minitest][:gem_version] = '3.0.1'
 
 # The version of the minitest-chef-handler gem to install
 default[:minitest][:chef_handler_gem_version] = '1.0.4'
-default[:minitest][:chef_handler_gem_source] = \
-  'http://artrepo.daptiv.com:8081/artifactory/rubygems-local/gems'
+default[:minitest][:chef_handler_gem_source] = nil
 
 # The version of the ci_reporter gem to install
 default[:minitest][:ci_reporter_gem_version] = '1.9.3'

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -2,7 +2,7 @@
 default[:minitest][:gem_version] = '3.0.1'
 
 # The version of the minitest-chef-handler gem to install
-default[:minitest][:chef_handler_gem_version] = '1.0.4'
+default[:minitest][:chef_handler_gem_version] = '1.0.3'
 default[:minitest][:chef_handler_gem_source] = nil
 
 # The version of the ci_reporter gem to install

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,6 +4,6 @@ maintainer_email 'davidpetzel@gmail.com'
 license 'Apache 2.0'
 description 'Installs and configures minitest-chef-handler'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '1.3.3'
+version '1.3.4'
 
 depends 'chef_handler'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -12,22 +12,9 @@ chef_gem 'minitest' do
   only_if { Chef::VERSION.to_f < 10.10 }
 end.run_action(:install)
 
-if node[:minitest][:chef_handler_gem_source]
-  remote_str = "#{Chef::Config[:file_cache_path]}/minitest-chef-handler-"
-  remote_str << "#{node[:minitest][:chef_handler_gem_version]}.gem"
-
-  remote_src = "#{node[:minitest][:chef_handler_gem_source]}/"
-  remote_src << "minitest-chef-handler-#{node[:minitest][:chef_handler_gem_version]}.gem"
-
-  remote_file remote_str do
-    source remote_src
-  end.run_action(:create)
-end
-
 chef_gem 'minitest-chef-handler' do
   version node[:minitest][:chef_handler_gem_version]
   action :nothing
-  source remote_str if remote_str
   # I won't pretend I understand WHY this works, but since the release of
   # Chef 11.8, this was causing errors related to the PUMA Gem
   # http://lists.opscode.com/sympa/arc/chef/2013-10/msg00592.html
@@ -35,6 +22,9 @@ chef_gem 'minitest-chef-handler' do
   # but for whatever reason, simply retrying once works. The initial
   # attempt still fails with the error in that thread, however
   # the retry succeeds...
+  if node[:minitest][:chef_handler_gem_source]
+    options "--source #{node[:minitest][:chef_handler_gem_source]}"
+  end
   retries 1
 end.run_action(:install)
 

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -12,18 +12,36 @@ chef_gem 'minitest' do
   only_if { Chef::VERSION.to_f < 10.10 }
 end.run_action(:install)
 
-chef_gem 'minitest-chef-handler' do
-  version node[:minitest][:chef_handler_gem_version]
-  action :nothing
-  # I won't pretend I understand WHY this works, but since the release of
-  # Chef 11.8, this was causing errors related to the PUMA Gem
-  # http://lists.opscode.com/sympa/arc/chef/2013-10/msg00592.html
-  # I tried using the conservative flag, as well as a few other hacks
-  # but for whatever reason, simply retrying once works. The initial
-  # attempt still fails with the error in that thread, however
-  # the retry succeeds...
-  retries 1
-end.run_action(:install)
+if node[:minitest][:chef_handler_gem_source]
+  remote_str = "#{Chef::Config[:file_cache_path]}/minitest-chef-handler-"
+  remote_str << "#{node[:minitest][:chef_handler_gem_version]}.gem"
+
+  remote_src = "#{node[:minitest][:chef_handler_gem_source]}/"
+  remote_src << "minitest-chef-handler-#{node[:minitest][:chef_handler_gem_version]}.gem"
+
+  remote_file remote_str do
+    source remote_src
+  end
+  chef_gem 'minitest-chef-handler' do
+    version node[:minitest][:chef_handler_gem_version]
+    action :nothing
+    source remote_str
+    retries 1
+  end.run_action(:install)
+else
+  chef_gem 'minitest-chef-handler' do
+    version node[:minitest][:chef_handler_gem_version]
+    action :nothing
+    # I won't pretend I understand WHY this works, but since the release of
+    # Chef 11.8, this was causing errors related to the PUMA Gem
+    # http://lists.opscode.com/sympa/arc/chef/2013-10/msg00592.html
+    # I tried using the conservative flag, as well as a few other hacks
+    # but for whatever reason, simply retrying once works. The initial
+    # attempt still fails with the error in that thread, however
+    # the retry succeeds...
+    retries 1
+  end.run_action(:install)
+end
 
 Gem.clear_paths
 # Ensure minitest gem is utilized

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -21,27 +21,22 @@ if node[:minitest][:chef_handler_gem_source]
 
   remote_file remote_str do
     source remote_src
-  end
-  chef_gem 'minitest-chef-handler' do
-    version node[:minitest][:chef_handler_gem_version]
-    action :nothing
-    source remote_str
-    retries 1
-  end.run_action(:install)
-else
-  chef_gem 'minitest-chef-handler' do
-    version node[:minitest][:chef_handler_gem_version]
-    action :nothing
-    # I won't pretend I understand WHY this works, but since the release of
-    # Chef 11.8, this was causing errors related to the PUMA Gem
-    # http://lists.opscode.com/sympa/arc/chef/2013-10/msg00592.html
-    # I tried using the conservative flag, as well as a few other hacks
-    # but for whatever reason, simply retrying once works. The initial
-    # attempt still fails with the error in that thread, however
-    # the retry succeeds...
-    retries 1
-  end.run_action(:install)
+  end.run_action(:create)
 end
+
+chef_gem 'minitest-chef-handler' do
+  version node[:minitest][:chef_handler_gem_version]
+  action :nothing
+  source remote_str if node[:minitest][:chef_handler_gem_source]
+  # I won't pretend I understand WHY this works, but since the release of
+  # Chef 11.8, this was causing errors related to the PUMA Gem
+  # http://lists.opscode.com/sympa/arc/chef/2013-10/msg00592.html
+  # I tried using the conservative flag, as well as a few other hacks
+  # but for whatever reason, simply retrying once works. The initial
+  # attempt still fails with the error in that thread, however
+  # the retry succeeds...
+  retries 1
+end.run_action(:install)
 
 Gem.clear_paths
 # Ensure minitest gem is utilized

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -27,7 +27,7 @@ end
 chef_gem 'minitest-chef-handler' do
   version node[:minitest][:chef_handler_gem_version]
   action :nothing
-  source remote_str if node[:minitest][:chef_handler_gem_source]
+  source remote_str if remote_str
   # I won't pretend I understand WHY this works, but since the release of
   # Chef 11.8, this was causing errors related to the PUMA Gem
   # http://lists.opscode.com/sympa/arc/chef/2013-10/msg00592.html


### PR DESCRIPTION
Added ability to specify a source for minitest-chef-handler gem other than the default of RubyGems.org.